### PR TITLE
fix "unparenthesized `a ? b : c ? d : e`"-Error in PHP8.0

### DIFF
--- a/src/Rating/RatingService.php
+++ b/src/Rating/RatingService.php
@@ -139,9 +139,9 @@ SQL;
             $label       = ($rating['totalRatings'] > 1 || $rating['totalRatings'] == 0) || ! $rating ? $GLOBALS['TL_LANG']['rateit']['rating_label'][1] : $GLOBALS['TL_LANG']['rateit']['rating_label'][0];
             $description = '%current%/%max% %type% (%count% [' . $GLOBALS['TL_LANG']['tl_rateit']['vote'][0] . '|' . $GLOBALS['TL_LANG']['tl_rateit']['vote'][1] . '])';
         } else {
-            $label       = count($labels) == 2
+            $label       = (count($labels) == 2
                 ? $labels[1]
-                : ($rating['totalRatings'] > 1 || $rating['totalRatings'] == 0 || ! $rating) ? $labels[2] : $labels[1];
+                : ($rating['totalRatings'] > 1 || $rating['totalRatings'] == 0 || ! $rating)) ? $labels[2] : $labels[1];
             $description = $template;
         }
         $actValue = $rating === false ? 0 : $rating['totalRatings'];


### PR DESCRIPTION
Bei der Umstellung auf PHP8.0 in Contao 4.13.12 wird folgender Fehler ausgeworfen:

`request.CRITICAL: Uncaught PHP Exception Symfony\Component\ErrorHandler\Error\FatalError: "Compile Error: Unparenthesized `a ? b : c ? d : e` is not supported. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`" at /var/www/web10/htdocs/dev/vendor/hofff/contao-rate-it/src/Rating/RatingService.php line 142 {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Compile Error: Unparenthesized `a ? b : c ? d : e` is not supported. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)` at /var/www/web10/htdocs/dev/vendor/hofff/contao-rate-it/src/Rating/RatingService.php:142)"} []`